### PR TITLE
Miami 2022 added missing retired reasons

### DIFF
--- a/src/data/seasons/2022/races/05-miami/race-results.yml
+++ b/src/data/seasons/2022/races/05-miami/race-results.yml
@@ -219,7 +219,7 @@
   timePenalty: "5.000"
   gap:
   interval:
-  reasonRetired:
+  reasonRetired: Front wing
   points:
   gridPosition: 16
 - position: 17
@@ -233,7 +233,7 @@
   timePenalty:
   gap:
   interval:
-  reasonRetired:
+  reasonRetired: Collision
   points:
   gridPosition: PL
 - position: DNF
@@ -247,7 +247,7 @@
   timePenalty:
   gap:
   interval:
-  reasonRetired:
+  reasonRetired: Suspension
   points:
   gridPosition: 7
 - position: DNF
@@ -261,7 +261,7 @@
   timePenalty:
   gap:
   interval:
-  reasonRetired:
+  reasonRetired: Collision
   points:
   gridPosition: 8
 - position: DNF
@@ -275,6 +275,6 @@
   timePenalty:
   gap:
   interval:
-  reasonRetired:
+  reasonRetired: Water leak
   points:
   gridPosition: 17


### PR DESCRIPTION
Hello!

There were "reasonRetired" missing for miami 2022 gp. I've put them.

[Source](https://en.wikipedia.org/wiki/2022_Miami_Grand_Prix#Race_classification)