### PR TITLE
fix: Updated 2026 Miami Grand Prix race start time (rescheduled by FIA)

### DIFF
--- a/src/data/seasons/2026/races/04-miami/race.yml
+++ b/src/data/seasons/2026/races/04-miami/race.yml
@@ -1,7 +1,7 @@
 id: 1153
 round: 4
 date: 2026-05-03
-time: 20:00
+time: 17:00
 grandPrixId: miami
 officialName: Formula 1 Crypto.com Miami Grand Prix 2026
 qualifyingFormat: KNOCKOUT


### PR DESCRIPTION
The 2026 Miami Grand Prix has been rescheduled by the FIA, F1 and the Miami promoter from a 16:00 EDT (20:00 UTC) start to **13:00 EDT (17:00 UTC)** due to a forecast of heavy thunderstorms later on race day.

Source (Formula1.com, 3 May 2026):
https://www.formula1.com/en/latest/article/breaking-new-start-time-confirmed-for-miami-grand-prix-following-weather-concerns.36mNfBCj5LLIRbgxAgjZIn

> "Following discussions between FIA, F1 and the Miami promoter, the decision has been taken to move the start of Sunday's Miami Grand Prix to 13:00 local time in Miami due to the weather forecast that is expected to bring heavier rainstorms later in the afternoon close to the original planned race start time."

This PR updates only the `time` field on `src/data/seasons/2026/races/04-miami/race.yml`. All other fields (date, support session schedule, etc.) are unchanged.
