### PR TITLE
Add F1·versus project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ For a full list of all contributors, see [GitHub Contributors](https://github.co
 
 - 🌐 [F1+](https://formula1.plus/) – F1 Predictions, Live Standings & Race Intelligence
 - 🍎 [F1nally](https://apps.apple.com/us/app/f1nally/id1618275556) – iOS app to quickly view the F1 schedule and results
+- 🌐 [F1·versus](https://f1-versus.com/) – F1 GOAT calculator: build your own formula, see the all-time ranking, share the debate
 - 🌐️ [fastestlap.io](https://fastestlap.io/) – Go-to source for Formula 1 history and statistics
 - 🌐️ [Gridvex](https://gridvex.app/) – Modern F1 stats & data web app covering standings, schedules, race reports, head-to-head and more
 - ⚙️ [Gridvex API](https://api.gridvex.app/docs/api) - Free F1 REST API with comprehensive endpoints


### PR DESCRIPTION
Adding f1·versus to the "Projects using F1DB" list.

**Site:** https://f1-versus.com  
**What it does:** Interactive F1 GOAT calculator. Users pick from 6 preset formulas or build their own with weighted sliders across 9 metrics (championships, wins, teammate H2H, peak dominance, etc.). The ranking and per-metric breakdowns update in real time and the URL is shareable.

**F1DB usage:** Pre-computes driver_stats at sync time from race_result, qualifying_result, fastest_lap, and season_driver_standings tables. Excludes 1950–1960 Indianapolis 500 results to keep the ranking F1-only.

Thanks for the dataset — built on F1DB v2026.0.1