### PR TITLE
fix: update driver full names

### DIFF
--- a/src/data/drivers/al-herman.yml
+++ b/src/data/drivers/al-herman.yml
@@ -2,7 +2,7 @@ id: al-herman
 name: Al Herman
 firstName: Al
 lastName: Herman
-fullName: Homer Gerald "Al" Herman
+fullName: Homer Gerald Herman
 abbreviation: HER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/al-herman.yml
+++ b/src/data/drivers/al-herman.yml
@@ -2,7 +2,7 @@ id: al-herman
 name: Al Herman
 firstName: Al
 lastName: Herman
-fullName: Al Herman
+fullName: Homer Gerald "Al" Herman
 abbreviation: HER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/al-keller.yml
+++ b/src/data/drivers/al-keller.yml
@@ -2,7 +2,7 @@ id: al-keller
 name: Al Keller
 firstName: Al
 lastName: Keller
-fullName: Al Keller
+fullName: Alvah August Keller
 abbreviation: KEL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/al-pease.yml
+++ b/src/data/drivers/al-pease.yml
@@ -2,7 +2,7 @@ id: al-pease
 name: Al Pease
 firstName: Al
 lastName: Pease
-fullName: Alan "Al" Victor Pease
+fullName: Alan Victor Pease
 abbreviation: PEA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/al-pease.yml
+++ b/src/data/drivers/al-pease.yml
@@ -2,7 +2,7 @@ id: al-pease
 name: Al Pease
 firstName: Al
 lastName: Pease
-fullName: Al Pease
+fullName: Alan "Al" Victor Pease
 abbreviation: PEA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/alan-rees.yml
+++ b/src/data/drivers/alan-rees.yml
@@ -2,7 +2,7 @@ id: alan-rees
 name: Alan Rees
 firstName: Alan
 lastName: Rees
-fullName: Alan Rees
+fullName: Alan Brinley Rees
 abbreviation: REE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/alan-rollinson.yml
+++ b/src/data/drivers/alan-rollinson.yml
@@ -2,7 +2,7 @@ id: alan-rollinson
 name: Alan Rollinson
 firstName: Alan
 lastName: Rollinson
-fullName: Alan Rollinson
+fullName: Alan William Rollinson
 abbreviation: ROL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/alex-caffi.yml
+++ b/src/data/drivers/alex-caffi.yml
@@ -2,7 +2,7 @@ id: alex-caffi
 name: Alex Caffi
 firstName: Alex
 lastName: Caffi
-fullName: Alessandro Caffi
+fullName: Alessandro Giuseppe Caffi
 abbreviation: CAF
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/alex-ribeiro.yml
+++ b/src/data/drivers/alex-ribeiro.yml
@@ -2,7 +2,7 @@ id: alex-ribeiro
 name: Alex Ribeiro
 firstName: Alex
 lastName: Ribeiro
-fullName: Alexandre Dias Ribeiro
+fullName: Alex Dias Ribeiro
 abbreviation: RIB
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/alexander-albon.yml
+++ b/src/data/drivers/alexander-albon.yml
@@ -2,7 +2,7 @@ id: alexander-albon
 name: Alexander Albon
 firstName: Alexander
 lastName: Albon
-fullName: Alexander Albon
+fullName: Alexander Philippe Albon Ansusinha
 abbreviation: ALB
 permanentNumber: 23
 gender: MALE

--- a/src/data/drivers/alexander-wurz.yml
+++ b/src/data/drivers/alexander-wurz.yml
@@ -2,7 +2,7 @@ id: alexander-wurz
 name: Alexander Wurz
 firstName: Alexander
 lastName: Wurz
-fullName: Alexander Wurz
+fullName: Alexander Georg Wurz
 abbreviation: WUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/andre-pilette.yml
+++ b/src/data/drivers/andre-pilette.yml
@@ -2,7 +2,7 @@ id: andre-pilette
 name: André Pilette
 firstName: André
 lastName: Pilette
-fullName: André Pilette
+fullName: André Théodore Pilette
 abbreviation: PIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/andre-simon.yml
+++ b/src/data/drivers/andre-simon.yml
@@ -2,7 +2,7 @@ id: andre-simon
 name: André Simon
 firstName: André
 lastName: Simon
-fullName: André Simon
+fullName: André Constant Simon
 abbreviation: SIM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/andy-linden.yml
+++ b/src/data/drivers/andy-linden.yml
@@ -2,7 +2,7 @@ id: andy-linden
 name: Andy Linden
 firstName: Andy
 lastName: Linden
-fullName: Andy Linden
+fullName: Andrew Logan Linden
 abbreviation: LIN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/anthony-joseph-foyt.yml
+++ b/src/data/drivers/anthony-joseph-foyt.yml
@@ -2,7 +2,7 @@ id: anthony-joseph-foyt
 name: Anthony Joseph Foyt
 firstName: Anthony Joseph
 lastName: Foyt
-fullName: Anthony Joseph Foyt
+fullName: Anthony Joseph Foyt Jr.
 abbreviation: FOY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/antonio-giovinazzi.yml
+++ b/src/data/drivers/antonio-giovinazzi.yml
@@ -2,7 +2,7 @@ id: antonio-giovinazzi
 name: Antonio Giovinazzi
 firstName: Antonio
 lastName: Giovinazzi
-fullName: Antonio Giovinazzi
+fullName: Antonio Maria Giovinazzi
 abbreviation: GIO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/art-bisch.yml
+++ b/src/data/drivers/art-bisch.yml
@@ -2,7 +2,7 @@ id: art-bisch
 name: Art Bisch
 firstName: Art
 lastName: Bisch
-fullName: Art Bisch
+fullName: Arthur James Bisch
 abbreviation: BIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/art-cross.yml
+++ b/src/data/drivers/art-cross.yml
@@ -2,7 +2,7 @@ id: art-cross
 name: Art Cross
 firstName: Art
 lastName: Cross
-fullName: Art Cross
+fullName: Arthur Francis Cross
 abbreviation: CRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bernd-schneider.yml
+++ b/src/data/drivers/bernd-schneider.yml
@@ -2,7 +2,7 @@ id: bernd-schneider
 name: Bernd Schneider
 firstName: Bernd
 lastName: Schneider
-fullName: Bernd Schneider
+fullName: Bernd Robert Schneider
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bertil-roos.yml
+++ b/src/data/drivers/bertil-roos.yml
@@ -2,7 +2,7 @@ id: bertil-roos
 name: Bertil Roos
 firstName: Bertil
 lastName: Roos
-fullName: Bertil Roos
+fullName: Bertil Ingemar Roos
 abbreviation: ROO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bertrand-gachot.yml
+++ b/src/data/drivers/bertrand-gachot.yml
@@ -2,7 +2,7 @@ id: bertrand-gachot
 name: Bertrand Gachot
 firstName: Bertrand
 lastName: Gachot
-fullName: Bertrand Gachot
+fullName: Bertrand Jean Louis Gachot
 abbreviation: GAC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-aston.yml
+++ b/src/data/drivers/bill-aston.yml
@@ -2,7 +2,7 @@ id: bill-aston
 name: Bill Aston
 firstName: Bill
 lastName: Aston
-fullName: William Aston
+fullName: William Simpson Aston
 abbreviation: AST
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-holland.yml
+++ b/src/data/drivers/bill-holland.yml
@@ -2,7 +2,7 @@ id: bill-holland
 name: Bill Holland
 firstName: Bill
 lastName: Holland
-fullName: Bill Holland
+fullName: Willard Saulsbury Holland
 abbreviation: HOL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-moss.yml
+++ b/src/data/drivers/bill-moss.yml
@@ -2,7 +2,7 @@ id: bill-moss
 name: Bill Moss
 firstName: Bill
 lastName: Moss
-fullName: Bill Moss
+fullName: William Frank Moss
 abbreviation: MOS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-schindler.yml
+++ b/src/data/drivers/bill-schindler.yml
@@ -2,7 +2,7 @@ id: bill-schindler
 name: Bill Schindler
 firstName: Bill
 lastName: Schindler
-fullName: Bill Schindler
+fullName: William Lawrence Schindler
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-vukovich.yml
+++ b/src/data/drivers/bill-vukovich.yml
@@ -2,7 +2,7 @@ id: bill-vukovich
 name: Bill Vukovich
 firstName: Bill
 lastName: Vukovich
-fullName: William John Vukovich
+fullName: William Vukovich
 abbreviation: VUK
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bill-whitehouse.yml
+++ b/src/data/drivers/bill-whitehouse.yml
@@ -2,7 +2,7 @@ id: bill-whitehouse
 name: Bill Whitehouse
 firstName: Bill
 lastName: Whitehouse
-fullName: Bill Whitehouse
+fullName: William James Whitehouse
 abbreviation: WHI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/billy-garrett.yml
+++ b/src/data/drivers/billy-garrett.yml
@@ -2,7 +2,7 @@ id: billy-garrett
 name: Billy Garrett
 firstName: Billy
 lastName: Garrett
-fullName: Billy Garrett
+fullName: William Joseph Garrett
 abbreviation: GAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-bondurant.yml
+++ b/src/data/drivers/bob-bondurant.yml
@@ -2,7 +2,7 @@ id: bob-bondurant
 name: Bob Bondurant
 firstName: Bob
 lastName: Bondurant
-fullName: Robert Bondurant
+fullName: Robert Lewis Bondurant
 abbreviation: BON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-drake.yml
+++ b/src/data/drivers/bob-drake.yml
@@ -2,7 +2,7 @@ id: bob-drake
 name: Bob Drake
 firstName: Bob
 lastName: Drake
-fullName: Bob Drake
+fullName: Eldon Robert Drake
 abbreviation: DRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-evans.yml
+++ b/src/data/drivers/bob-evans.yml
@@ -2,7 +2,7 @@ id: bob-evans
 name: Bob Evans
 firstName: Bob
 lastName: Evans
-fullName: Robert Evans
+fullName: Robert Neville Anthony Evans
 abbreviation: EVA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-said.yml
+++ b/src/data/drivers/bob-said.yml
@@ -2,7 +2,7 @@ id: bob-said
 name: Bob Said
 firstName: Bob
 lastName: Said
-fullName: Boris Robert Said
+fullName: Boris Robert Said Jr.
 abbreviation: SAI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-said.yml
+++ b/src/data/drivers/bob-said.yml
@@ -2,7 +2,7 @@ id: bob-said
 name: Bob Said
 firstName: Bob
 lastName: Said
-fullName: Boris Said
+fullName: Boris Robert Said
 abbreviation: SAI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-scott.yml
+++ b/src/data/drivers/bob-scott.yml
@@ -2,7 +2,7 @@ id: bob-scott
 name: Bob Scott
 firstName: Bob
 lastName: Scott
-fullName: Bob Scott
+fullName: Robert Franklin Scott
 abbreviation: SCO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bob-veith.yml
+++ b/src/data/drivers/bob-veith.yml
@@ -2,7 +2,7 @@ id: bob-veith
 name: Bob Veith
 firstName: Bob
 lastName: Veith
-fullName: Bob Veith
+fullName: Robert James Veith
 abbreviation: VEI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bobby-ball.yml
+++ b/src/data/drivers/bobby-ball.yml
@@ -2,7 +2,7 @@ id: bobby-ball
 name: Bobby Ball
 firstName: Bobby
 lastName: Ball
-fullName: Robert K. Ball
+fullName: Robert Kay Ball
 abbreviation: BAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bobby-grim.yml
+++ b/src/data/drivers/bobby-grim.yml
@@ -2,7 +2,7 @@ id: bobby-grim
 name: Bobby Grim
 firstName: Bobby
 lastName: Grim
-fullName: Robert Grim
+fullName: Robert Harold Grim
 abbreviation: GRI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/brendon-hartley.yml
+++ b/src/data/drivers/brendon-hartley.yml
@@ -2,7 +2,7 @@ id: brendon-hartley
 name: Brendon Hartley
 firstName: Brendon
 lastName: Hartley
-fullName: Brendon Hartley
+fullName: Brendon Morris Hartley
 abbreviation: HAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/brian-hart.yml
+++ b/src/data/drivers/brian-hart.yml
@@ -2,7 +2,7 @@ id: brian-hart
 name: Brian Hart
 firstName: Brian
 lastName: Hart
-fullName: Brian Hart
+fullName: Brian Roger Hart
 abbreviation: HAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bruce-halford.yml
+++ b/src/data/drivers/bruce-halford.yml
@@ -2,7 +2,7 @@ id: bruce-halford
 name: Bruce Halford
 firstName: Bruce
 lastName: Halford
-fullName: Bruce Halford
+fullName: Bruce Henley Halford
 abbreviation: HAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/bruce-kessler.yml
+++ b/src/data/drivers/bruce-kessler.yml
@@ -2,7 +2,7 @@ id: bruce-kessler
 name: Bruce Kessler
 firstName: Bruce
 lastName: Kessler
-fullName: Bruce Kessler
+fullName: Bruce Michael Kessler
 abbreviation: KES
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/cal-niday.yml
+++ b/src/data/drivers/cal-niday.yml
@@ -2,7 +2,7 @@ id: cal-niday
 name: Cal Niday
 firstName: Cal
 lastName: Niday
-fullName: Cal Niday
+fullName: Calvin Lee Niday
 abbreviation: NID
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/carl-forberg.yml
+++ b/src/data/drivers/carl-forberg.yml
@@ -2,7 +2,7 @@ id: carl-forberg
 name: Carl Forberg
 firstName: Carl
 lastName: Forberg
-fullName: Carl Forberg
+fullName: Carl Roy Forberg
 abbreviation: FOR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/charles-de-tornaco.yml
+++ b/src/data/drivers/charles-de-tornaco.yml
@@ -2,7 +2,7 @@ id: charles-de-tornaco
 name: Charles de Tornaco
 firstName: Charles
 lastName: De Tornaco
-fullName: Charles de Tornaco
+fullName: Baron Charles Victor Raymond André Evance de Tornaco
 abbreviation: DET
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/charles-pic.yml
+++ b/src/data/drivers/charles-pic.yml
@@ -2,7 +2,7 @@ id: charles-pic
 name: Charles Pic
 firstName: Charles
 lastName: Pic
-fullName: Charles Pic
+fullName: Charles Maurice Marcel Pic
 abbreviation: PIC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chet-miller.yml
+++ b/src/data/drivers/chet-miller.yml
@@ -2,7 +2,7 @@ id: chet-miller
 name: Chet Miller
 firstName: Chet
 lastName: Miller
-fullName: Chet Miller
+fullName: Chester Joseph Miller
 abbreviation: MIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chico-serra.yml
+++ b/src/data/drivers/chico-serra.yml
@@ -2,7 +2,7 @@ id: chico-serra
 name: Chico Serra
 firstName: Chico
 lastName: Serra
-fullName: Francisco Serra
+fullName: Francisco Adolpho Serra
 abbreviation: SER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chris-craft.yml
+++ b/src/data/drivers/chris-craft.yml
@@ -2,7 +2,7 @@ id: chris-craft
 name: Chris Craft
 firstName: Chris
 lastName: Craft
-fullName: Christopher Craft
+fullName: Christopher Adrian Craft
 abbreviation: CRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chris-irwin.yml
+++ b/src/data/drivers/chris-irwin.yml
@@ -2,7 +2,7 @@ id: chris-irwin
 name: Chris Irwin
 firstName: Chris
 lastName: Irwin
-fullName: Chris Irwin
+fullName: Christopher Frank Stuart Irwin
 abbreviation: IRW
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chris-lawrence.yml
+++ b/src/data/drivers/chris-lawrence.yml
@@ -2,7 +2,7 @@ id: chris-lawrence
 name: Chris Lawrence
 firstName: Chris
 lastName: Lawrence
-fullName: Christopher J. Lawrence
+fullName: Christopher John Lawrence
 abbreviation: LAW
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/christian-danner.yml
+++ b/src/data/drivers/christian-danner.yml
@@ -2,7 +2,7 @@ id: christian-danner
 name: Christian Danner
 firstName: Christian
 lastName: Danner
-fullName: Christian Danner
+fullName: Christian Josef Danner
 abbreviation: DAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chuck-arnold.yml
+++ b/src/data/drivers/chuck-arnold.yml
@@ -2,7 +2,7 @@ id: chuck-arnold
 name: Chuck Arnold
 firstName: Chuck
 lastName: Arnold
-fullName: Chuck Arnold
+fullName: Charles Russell Arnold
 abbreviation: ARN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chuck-daigh.yml
+++ b/src/data/drivers/chuck-daigh.yml
@@ -2,7 +2,7 @@ id: chuck-daigh
 name: Chuck Daigh
 firstName: Chuck
 lastName: Daigh
-fullName: Chuck Daigh
+fullName: Charles George Daigh
 abbreviation: DAI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/chuck-stevenson.yml
+++ b/src/data/drivers/chuck-stevenson.yml
@@ -2,7 +2,7 @@ id: chuck-stevenson
 name: Chuck Stevenson
 firstName: Chuck
 lastName: Stevenson
-fullName: Charles Stevenson
+fullName: Charles Joseph Stevenson
 abbreviation: STE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/daniel-ricciardo.yml
+++ b/src/data/drivers/daniel-ricciardo.yml
@@ -2,7 +2,7 @@ id: daniel-ricciardo
 name: Daniel Ricciardo
 firstName: Daniel
 lastName: Ricciardo
-fullName: Daniel Ricciardo
+fullName: Daniel Joseph Ricciardo
 abbreviation: RIC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/danny-kladis.yml
+++ b/src/data/drivers/danny-kladis.yml
@@ -2,7 +2,7 @@ id: danny-kladis
 name: Danny Kladis
 firstName: Danny
 lastName: Kladis
-fullName: Danny Kladis
+fullName: Dan Peter Kladis
 abbreviation: KLA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/danny-ongais.yml
+++ b/src/data/drivers/danny-ongais.yml
@@ -2,7 +2,7 @@ id: danny-ongais
 name: Danny Ongais
 firstName: Danny
 lastName: Ongais
-fullName: Danny Ongais
+fullName: Ezekiel Ongais
 abbreviation: ONG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/dave-morgan.yml
+++ b/src/data/drivers/dave-morgan.yml
@@ -2,7 +2,7 @@ id: dave-morgan
 name: Dave Morgan
 firstName: Dave
 lastName: Morgan
-fullName: Dave Morgan
+fullName: David Rowland John Morgan
 abbreviation: MOR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/david-brabham.yml
+++ b/src/data/drivers/david-brabham.yml
@@ -2,7 +2,7 @@ id: david-brabham
 name: David Brabham
 firstName: David
 lastName: Brabham
-fullName: David Brabham
+fullName: David Philip Brabham
 abbreviation: BRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/david-kennedy.yml
+++ b/src/data/drivers/david-kennedy.yml
@@ -2,7 +2,7 @@ id: david-kennedy
 name: David Kennedy
 firstName: David
 lastName: Kennedy
-fullName: David Kennedy
+fullName: David Paul Kennedy
 abbreviation: KEN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/david-murray.yml
+++ b/src/data/drivers/david-murray.yml
@@ -2,7 +2,7 @@ id: david-murray
 name: David Murray
 firstName: David
 lastName: Murray
-fullName: David Murray
+fullName: David Hugh Murray
 abbreviation: MUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/dempsey-wilson.yml
+++ b/src/data/drivers/dempsey-wilson.yml
@@ -2,7 +2,7 @@ id: dempsey-wilson
 name: Dempsey Wilson
 firstName: Dempsey
 lastName: Wilson
-fullName: Dempsey Cothrin Wilson
+fullName: Dempsey Cothrien Wilson
 abbreviation: WIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/derek-daly.yml
+++ b/src/data/drivers/derek-daly.yml
@@ -2,7 +2,7 @@ id: derek-daly
 name: Derek Daly
 firstName: Derek
 lastName: Daly
-fullName: Derek Daly
+fullName: Derek Patrick Daly
 abbreviation: DAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/dick-rathmann.yml
+++ b/src/data/drivers/dick-rathmann.yml
@@ -2,7 +2,7 @@ id: dick-rathmann
 name: Dick Rathmann
 firstName: Dick
 lastName: Rathmann
-fullName: James Rathmann
+fullName: James Merwin Rathmann
 abbreviation: RAT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/dieter-quester.yml
+++ b/src/data/drivers/dieter-quester.yml
@@ -2,7 +2,7 @@ id: dieter-quester
 name: Dieter Quester
 firstName: Dieter
 lastName: Quester
-fullName: Dieter Quester
+fullName: Dietrich Erwin Quester
 abbreviation: QUE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/don-branson.yml
+++ b/src/data/drivers/don-branson.yml
@@ -2,7 +2,7 @@ id: don-branson
 name: Don Branson
 firstName: Don
 lastName: Branson
-fullName: Donald L. Branson
+fullName: Donald Laverne Branson
 abbreviation: BRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/duane-carter.yml
+++ b/src/data/drivers/duane-carter.yml
@@ -2,7 +2,7 @@ id: duane-carter
 name: Duane Carter
 firstName: Duane
 lastName: Carter
-fullName: Duane Carter
+fullName: Duane Claude Carter
 abbreviation: CAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/duke-dinsmore.yml
+++ b/src/data/drivers/duke-dinsmore.yml
@@ -2,7 +2,7 @@ id: duke-dinsmore
 name: Duke Dinsmore
 firstName: Duke
 lastName: Dinsmore
-fullName: J. Carlyle Dinsmore
+fullName: Carlyle John Dinsmoor
 abbreviation: DIN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/duke-nalon.yml
+++ b/src/data/drivers/duke-nalon.yml
@@ -2,7 +2,7 @@ id: duke-nalon
 name: Duke Nalon
 firstName: Dennis
 lastName: Nalon
-fullName: Dennis Nalon
+fullName: Dennis Clayton Nalon
 abbreviation: NAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/eddie-russo.yml
+++ b/src/data/drivers/eddie-russo.yml
@@ -2,7 +2,7 @@ id: eddie-russo
 name: Eddie Russo
 firstName: Eddie
 lastName: Russo
-fullName: Eddie Russo
+fullName: Edward Leon Russo
 abbreviation: RUS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/elmer-george.yml
+++ b/src/data/drivers/elmer-george.yml
@@ -2,7 +2,7 @@ id: elmer-george
 name: Elmer George
 firstName: Elmer
 lastName: George
-fullName: Elmer George
+fullName: Elmer Ray George
 abbreviation: GEO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/emmanuel-de-graffenried.yml
+++ b/src/data/drivers/emmanuel-de-graffenried.yml
@@ -2,7 +2,7 @@ id: emmanuel-de-graffenried
 name: Emmanuel de Graffenried
 firstName: Emmanuel
 lastName: De Graffenried
-fullName: Emmanuel de Graffenried
+fullName: Baron Emmanuel Leo Ludwig de Graffenried
 abbreviation: DEG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/enrico-bertaggia.yml
+++ b/src/data/drivers/enrico-bertaggia.yml
@@ -2,7 +2,7 @@ id: enrico-bertaggia
 name: Enrico Bertaggia
 firstName: Enrico
 lastName: Bertaggia
-fullName: Enrico Bertaggia
+fullName: Enrico Agostino Bertaggia
 abbreviation: BER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/eric-thompson.yml
+++ b/src/data/drivers/eric-thompson.yml
@@ -2,7 +2,7 @@ id: eric-thompson
 name: Eric Thompson
 firstName: Eric
 lastName: Thompson
-fullName: Eric Thompson
+fullName: Eric David Thompson
 abbreviation: THO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/eric-van-de-poele.yml
+++ b/src/data/drivers/eric-van-de-poele.yml
@@ -2,7 +2,7 @@ id: eric-van-de-poele
 name: Eric van de Poele
 firstName: Eric
 lastName: Van de Poele
-fullName: Eric van de Poele
+fullName: Eric Francis Edouard Ghislain Thérèse van de Poele
 abbreviation: VAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/erik-comas.yml
+++ b/src/data/drivers/erik-comas.yml
@@ -2,7 +2,7 @@ id: erik-comas
 name: Érik Comas
 firstName: Érik
 lastName: Comas
-fullName: Érik Comas
+fullName: Érik Gilbert Comas
 abbreviation: COM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/erwin-bauer.yml
+++ b/src/data/drivers/erwin-bauer.yml
@@ -2,7 +2,7 @@ id: erwin-bauer
 name: Erwin Bauer
 firstName: Erwin
 lastName: Bauer
-fullName: Erwin Bauer
+fullName: Erwin Erich Bauer
 abbreviation: BAU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/esteban-ocon.yml
+++ b/src/data/drivers/esteban-ocon.yml
@@ -2,7 +2,7 @@ id: esteban-ocon
 name: Esteban Ocon
 firstName: Esteban
 lastName: Ocon
-fullName: Esteban Ocon
+fullName: Esteban José Jean-Pierre Ocon-Khelfane
 abbreviation: OCO
 permanentNumber: 31
 gender: MALE

--- a/src/data/drivers/esteban-tuero.yml
+++ b/src/data/drivers/esteban-tuero.yml
@@ -2,7 +2,7 @@ id: esteban-tuero
 name: Esteban Tuero
 firstName: Esteban
 lastName: Tuero
-fullName: Esteban Tuero
+fullName: Esteban Eduardo Tuero
 abbreviation: TUE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/francois-migault.yml
+++ b/src/data/drivers/francois-migault.yml
@@ -2,7 +2,7 @@ id: francois-migault
 name: François Migault
 firstName: François
 lastName: Migault
-fullName: François Migault
+fullName: François Marie Edouard Migault
 abbreviation: MIG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/frank-armi.yml
+++ b/src/data/drivers/frank-armi.yml
@@ -2,7 +2,7 @@ id: frank-armi
 name: Frank Armi
 firstName: Frank
 lastName: Armi
-fullName: Frank Simon Armi Jr
+fullName: Frank Simon Armi Jr.
 abbreviation: ARM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/frank-armi.yml
+++ b/src/data/drivers/frank-armi.yml
@@ -2,7 +2,7 @@ id: frank-armi
 name: Frank Armi
 firstName: Frank
 lastName: Armi
-fullName: Frank Armi
+fullName: Frank Simon Armi Jr
 abbreviation: ARM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/frank-dochnal.yml
+++ b/src/data/drivers/frank-dochnal.yml
@@ -2,7 +2,7 @@ id: frank-dochnal
 name: Frank Dochnal
 firstName: Frank
 lastName: Dochnal
-fullName: Frank J. Dochnal
+fullName: Frank Jack Dochnal
 abbreviation: DOC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/fred-gamble.yml
+++ b/src/data/drivers/fred-gamble.yml
@@ -2,7 +2,7 @@ id: fred-gamble
 name: Fred Gamble
 firstName: Fred
 lastName: Gamble
-fullName: Fred K. Gamble
+fullName: Frederick Kesner Gamble
 abbreviation: GAM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/fritz-riess.yml
+++ b/src/data/drivers/fritz-riess.yml
@@ -2,7 +2,7 @@ id: fritz-riess
 name: Fritz Riess
 firstName: Fritz
 lastName: Riess
-fullName: Fritz Riess
+fullName: Friedrich Riess
 abbreviation: RIE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gabriel-bortoleto.yml
+++ b/src/data/drivers/gabriel-bortoleto.yml
@@ -2,7 +2,7 @@ id: gabriel-bortoleto
 name: Gabriel Bortoleto
 firstName: Gabriel
 lastName: Bortoleto
-fullName: Gabriel Bortoleto Oliveira
+fullName: Gabriel Lourenzo Bortoleto Oliveira
 abbreviation: BOR
 permanentNumber: 5
 gender: MALE

--- a/src/data/drivers/gary-brabham.yml
+++ b/src/data/drivers/gary-brabham.yml
@@ -2,7 +2,7 @@ id: gary-brabham
 name: Gary Brabham
 firstName: Gary
 lastName: Brabham
-fullName: Gary Brabham
+fullName: Gary Thomas Brabham
 abbreviation: BRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gene-force.yml
+++ b/src/data/drivers/gene-force.yml
@@ -2,7 +2,7 @@ id: gene-force
 name: Gene Force
 firstName: Gene
 lastName: Force
-fullName: Gene Force
+fullName: Eugene Robert Force
 abbreviation: FOR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-amick.yml
+++ b/src/data/drivers/george-amick.yml
@@ -2,7 +2,7 @@ id: george-amick
 name: George Amick
 firstName: George
 lastName: Amick
-fullName: George Reggie Amick, Jr.
+fullName: George Reggie Amick Jr.
 abbreviation: AMI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-amick.yml
+++ b/src/data/drivers/george-amick.yml
@@ -2,7 +2,7 @@ id: george-amick
 name: George Amick
 firstName: George
 lastName: Amick
-fullName: George R. Amick
+fullName: George Reggie Amick, Jr.
 abbreviation: AMI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-constantine.yml
+++ b/src/data/drivers/george-constantine.yml
@@ -2,7 +2,7 @@ id: george-constantine
 name: George Constantine
 firstName: George
 lastName: Constantine
-fullName: George J. Constantine
+fullName: George John Constantine
 abbreviation: CON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-follmer.yml
+++ b/src/data/drivers/george-follmer.yml
@@ -2,7 +2,7 @@ id: george-follmer
 name: George Follmer
 firstName: George
 lastName: Follmer
-fullName: George Follmer
+fullName: George Richard Follmer
 abbreviation: FOL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-fonder.yml
+++ b/src/data/drivers/george-fonder.yml
@@ -2,7 +2,7 @@ id: george-fonder
 name: George Fonder
 firstName: George
 lastName: Fonder
-fullName: George Fonder
+fullName: George Thomas Fonder
 abbreviation: FON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/george-russell.yml
+++ b/src/data/drivers/george-russell.yml
@@ -2,7 +2,7 @@ id: george-russell
 name: George Russell
 firstName: George
 lastName: Russell
-fullName: George Russell
+fullName: George William Russell
 abbreviation: RUS
 permanentNumber: 63
 gender: MALE

--- a/src/data/drivers/gerard-larrousse.yml
+++ b/src/data/drivers/gerard-larrousse.yml
@@ -2,7 +2,7 @@ id: gerard-larrousse
 name: Gérard Larrousse
 firstName: Gérard
 lastName: Larrousse
-fullName: Gérard Larrousse
+fullName: Gérard Gilles Marie Armand Larrousse
 abbreviation: LAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gerry-ashmore.yml
+++ b/src/data/drivers/gerry-ashmore.yml
@@ -2,7 +2,7 @@ id: gerry-ashmore
 name: Gerry Ashmore
 firstName: Gerry
 lastName: Ashmore
-fullName: Gerry Ashmore
+fullName: Joseph Frederick Harold Gerald Ashmore
 abbreviation: ASH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gianfranco-brancatelli.yml
+++ b/src/data/drivers/gianfranco-brancatelli.yml
@@ -2,7 +2,7 @@ id: gianfranco-brancatelli
 name: Gianfranco Brancatelli
 firstName: Gianfranco
 lastName: Brancatelli
-fullName: Gianfranco Brancatelli
+fullName: Gianfranco Gaetano Brancatelli
 abbreviation: BRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gino-munaron.yml
+++ b/src/data/drivers/gino-munaron.yml
@@ -2,7 +2,7 @@ id: gino-munaron
 name: Gino Munaron
 firstName: Gino
 lastName: Munaron
-fullName: Gino Munaron
+fullName: Virginio Lugli Munaron
 abbreviation: MUN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/graham-mcrae.yml
+++ b/src/data/drivers/graham-mcrae.yml
@@ -2,7 +2,7 @@ id: graham-mcrae
 name: Graham McRae
 firstName: Graham
 lastName: McRae
-fullName: Graham McRae
+fullName: Graham Peter McRae
 abbreviation: MCR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/graham-whitehead.yml
+++ b/src/data/drivers/graham-whitehead.yml
@@ -2,7 +2,7 @@ id: graham-whitehead
 name: Graham Whitehead
 firstName: Graham
 lastName: Whitehead
-fullName: Anthony Graham Whitehead
+fullName: Alfred Graham Whitehead
 abbreviation: WHI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gunnar-nilsson.yml
+++ b/src/data/drivers/gunnar-nilsson.yml
@@ -2,7 +2,7 @@ id: gunnar-nilsson
 name: Gunnar Nilsson
 firstName: Gunnar
 lastName: Nilsson
-fullName: Gunnar Nilsson
+fullName: Gunnar Axel Arvid Nilsson
 abbreviation: NIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/gus-hutchison.yml
+++ b/src/data/drivers/gus-hutchison.yml
@@ -2,7 +2,7 @@ id: gus-hutchison
 name: Gus Hutchison
 firstName: Gus
 lastName: Hutchison
-fullName: Gus Hutchison
+fullName: Augustus Hutchison
 abbreviation: HUT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/hans-heyer.yml
+++ b/src/data/drivers/hans-heyer.yml
@@ -2,7 +2,7 @@ id: hans-heyer
 name: Hans Heyer
 firstName: Hans
 lastName: Heyer
-fullName: Hans Heyer
+fullName: Johann Josef Heyer
 abbreviation: HEY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/harry-schell.yml
+++ b/src/data/drivers/harry-schell.yml
@@ -2,7 +2,7 @@ id: harry-schell
 name: Harry Schell
 firstName: Harry
 lastName: Schell
-fullName: Henry O'Reilly Schell
+fullName: Harry Lawrence O'Reilly Schell
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/heini-walter.yml
+++ b/src/data/drivers/heini-walter.yml
@@ -2,7 +2,7 @@ id: heini-walter
 name: Heini Walter
 firstName: Heini
 lastName: Walter
-fullName: Heini Walter
+fullName: Heinrich Walter
 abbreviation: WAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/heinz-schiller.yml
+++ b/src/data/drivers/heinz-schiller.yml
@@ -2,7 +2,7 @@ id: heinz-schiller
 name: Heinz Schiller
 firstName: Heinz
 lastName: Schiller
-fullName: Heinz Schiller
+fullName: Heinz Rudolf Schiller
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/helmuth-koinigg.yml
+++ b/src/data/drivers/helmuth-koinigg.yml
@@ -2,7 +2,7 @@ id: helmuth-koinigg
 name: Helmuth Koinigg
 firstName: Helmuth
 lastName: Koinigg
-fullName: Helmuth Koinigg
+fullName: Helmut Koinigg
 abbreviation: KOI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/helmuth-koinigg.yml
+++ b/src/data/drivers/helmuth-koinigg.yml
@@ -2,7 +2,7 @@ id: helmuth-koinigg
 name: Helmuth Koinigg
 firstName: Helmuth
 lastName: Koinigg
-fullName: Helmut Koinigg
+fullName: Helmuth Koinigg
 abbreviation: KOI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/henry-banks.yml
+++ b/src/data/drivers/henry-banks.yml
@@ -2,7 +2,7 @@ id: henry-banks
 name: Henry Banks
 firstName: Henry
 lastName: Banks
-fullName: Henry Banks
+fullName: Henry Edwin Banks
 abbreviation: BAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/henry-taylor.yml
+++ b/src/data/drivers/henry-taylor.yml
@@ -2,7 +2,7 @@ id: henry-taylor
 name: Henry Taylor
 firstName: Henry
 lastName: Taylor
-fullName: Henry Taylor
+fullName: Henry Charles Taylor
 abbreviation: TAY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/hermann-lang.yml
+++ b/src/data/drivers/hermann-lang.yml
@@ -2,7 +2,7 @@ id: hermann-lang
 name: Hermann Lang
 firstName: Hermann
 lastName: Lang
-fullName: Hermann Lang
+fullName: Hermann Albert Lang
 abbreviation: LAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ian-burgess.yml
+++ b/src/data/drivers/ian-burgess.yml
@@ -2,7 +2,7 @@ id: ian-burgess
 name: Ian Burgess
 firstName: Ian
 lastName: Burgess
-fullName: Ian Burgess
+fullName: Ian John Burgess
 abbreviation: BUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ian-stewart.yml
+++ b/src/data/drivers/ian-stewart.yml
@@ -2,7 +2,7 @@ id: ian-stewart
 name: Ian Stewart
 firstName: Ian
 lastName: Stewart
-fullName: Ian Macpherson M. Stewart
+fullName: Ian Macpherson McCallum Stewart
 abbreviation: STE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ignazio-giunti.yml
+++ b/src/data/drivers/ignazio-giunti.yml
@@ -2,7 +2,7 @@ id: ignazio-giunti
 name: Ignazio Giunti
 firstName: Ignazio
 lastName: Giunti
-fullName: Ignazio Giunti
+fullName: Ignazio Francesco Giunti
 abbreviation: GIU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ingo-hoffmann.yml
+++ b/src/data/drivers/ingo-hoffmann.yml
@@ -2,7 +2,7 @@ id: ingo-hoffmann
 name: Ingo Hoffmann
 firstName: Ingo
 lastName: Hoffmann
-fullName: Ingo Hoffmann
+fullName: Ingo Ott Hoffmann
 abbreviation: HOF
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jack-aitken.yml
+++ b/src/data/drivers/jack-aitken.yml
@@ -2,7 +2,7 @@ id: jack-aitken
 name: Jack Aitken
 firstName: Jack
 lastName: Aitken
-fullName: Jack Aitken
+fullName: Jack Anthony Han-Aitken
 abbreviation: AIT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jack-doohan.yml
+++ b/src/data/drivers/jack-doohan.yml
@@ -2,7 +2,7 @@ id: jack-doohan
 name: Jack Doohan
 firstName: Jack
 lastName: Doohan
-fullName: Jack Doohan
+fullName: Jack Michael Doohan
 abbreviation: DOO
 permanentNumber: 7
 gender: MALE

--- a/src/data/drivers/jack-fairman.yml
+++ b/src/data/drivers/jack-fairman.yml
@@ -2,7 +2,7 @@ id: jack-fairman
 name: Jack Fairman
 firstName: Jack
 lastName: Fairman
-fullName: Jack Fairman
+fullName: John Eric George Fairman
 abbreviation: FAI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jack-turner.yml
+++ b/src/data/drivers/jack-turner.yml
@@ -2,7 +2,7 @@ id: jack-turner
 name: Jack Turner
 firstName: Jack
 lastName: Turner
-fullName: Jack Turner
+fullName: John Ellsworth Turner Jr
 abbreviation: TUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jack-turner.yml
+++ b/src/data/drivers/jack-turner.yml
@@ -2,7 +2,7 @@ id: jack-turner
 name: Jack Turner
 firstName: Jack
 lastName: Turner
-fullName: John Ellsworth Turner Jr
+fullName: John Ellsworth Turner Jr.
 abbreviation: TUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jackie-lewis.yml
+++ b/src/data/drivers/jackie-lewis.yml
@@ -2,7 +2,7 @@ id: jackie-lewis
 name: Jackie Lewis
 firstName: Jackie
 lastName: Lewis
-fullName: Jackie Lewis
+fullName: Jack Rex Lewis
 abbreviation: LEW
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jacky-ickx.yml
+++ b/src/data/drivers/jacky-ickx.yml
@@ -2,7 +2,7 @@ id: jacky-ickx
 name: Jacky Ickx
 firstName: Jacky
 lastName: Ickx
-fullName: Jacques Bernard Ickx
+fullName: Jacques Bernard Edmon Martin Henri Ickx
 abbreviation: ICK
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jacques-laffite.yml
+++ b/src/data/drivers/jacques-laffite.yml
@@ -2,7 +2,7 @@ id: jacques-laffite
 name: Jacques Laffite
 firstName: Jacques
 lastName: Laffite
-fullName: Jacques-Henri Laffite
+fullName: Jacques-Henri Marie Sabin Laffite
 abbreviation: LAF
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jan-lammers.yml
+++ b/src/data/drivers/jan-lammers.yml
@@ -2,7 +2,7 @@ id: jan-lammers
 name: Jan Lammers
 firstName: Jan
 lastName: Lammers
-fullName: Johannes Lammers
+fullName: Johannes Antonius Lammers
 abbreviation: LAM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jay-chamberlain.yml
+++ b/src/data/drivers/jay-chamberlain.yml
@@ -2,7 +2,7 @@ id: jay-chamberlain
 name: Jay Chamberlain
 firstName: Jay
 lastName: Chamberlain
-fullName: Jay Chamberlain
+fullName: Jay Clifford Chamberlain
 abbreviation: CHA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jean-alesi.yml
+++ b/src/data/drivers/jean-alesi.yml
@@ -2,7 +2,7 @@ id: jean-alesi
 name: Jean Alesi
 firstName: Jean
 lastName: Alesi
-fullName: Giovanni Alesi
+fullName: Giovanni Roberto Alesi
 abbreviation: ALE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jean-alesi.yml
+++ b/src/data/drivers/jean-alesi.yml
@@ -2,7 +2,7 @@ id: jean-alesi
 name: Jean Alesi
 firstName: Jean
 lastName: Alesi
-fullName: Giovanni Roberto Alesi
+fullName: Jean Robert Alesi
 abbreviation: ALE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jean-christophe-boullion.yml
+++ b/src/data/drivers/jean-christophe-boullion.yml
@@ -2,7 +2,7 @@ id: jean-christophe-boullion
 name: Jean-Christophe Boullion
 firstName: Jean-Christophe
 lastName: Boullion
-fullName: Jean-Christophe Boullion
+fullName: Jean-Christophe Joël Louis Boullion
 abbreviation: BOU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jean-eric-vergne.yml
+++ b/src/data/drivers/jean-eric-vergne.yml
@@ -2,7 +2,7 @@ id: jean-eric-vergne
 name: Jean-Éric Vergne
 firstName: Jean-Éric
 lastName: Vergne
-fullName: Jean-Éric Vergne
+fullName: Jean-Éric Serge Raymond Vergne
 abbreviation: VER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jean-marc-gounon.yml
+++ b/src/data/drivers/jean-marc-gounon.yml
@@ -2,7 +2,7 @@ id: jean-marc-gounon
 name: Jean-Marc Gounon
 firstName: Jean-Marc
 lastName: Gounon
-fullName: Jean-Marc Gounon
+fullName: Jean-Marc André Gounon
 abbreviation: GOU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jerry-hoyt.yml
+++ b/src/data/drivers/jerry-hoyt.yml
@@ -2,7 +2,7 @@ id: jerry-hoyt
 name: Jerry Hoyt
 firstName: Jerry
 lastName: Hoyt
-fullName: Gerald F. Hoyt
+fullName: Gerald Frederick Hoyt
 abbreviation: HOY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jim-crawford.yml
+++ b/src/data/drivers/jim-crawford.yml
@@ -2,7 +2,7 @@ id: jim-crawford
 name: Jim Crawford
 firstName: Jim
 lastName: Crawford
-fullName: Jim Crawford
+fullName: James Alan Crawford
 abbreviation: CRA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jim-hall.yml
+++ b/src/data/drivers/jim-hall.yml
@@ -2,7 +2,7 @@ id: jim-hall
 name: Jim Hall
 firstName: Jim
 lastName: Hall
-fullName: Jim Hall
+fullName: James Ellis Hall
 abbreviation: HAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jim-hurtubise.yml
+++ b/src/data/drivers/jim-hurtubise.yml
@@ -2,7 +2,7 @@ id: jim-hurtubise
 name: Jim Hurtubise
 firstName: Jim
 lastName: Hurtubise
-fullName: James Hurtubise
+fullName: James Ernest Hurtubise
 abbreviation: HUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jim-mcwithey.yml
+++ b/src/data/drivers/jim-mcwithey.yml
@@ -2,7 +2,7 @@ id: jim-mcwithey
 name: Jim McWithey
 firstName: Jim
 lastName: McWithey
-fullName: Jim McWithey
+fullName: James Robert McWithey
 abbreviation: MCW
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jim-rigsby.yml
+++ b/src/data/drivers/jim-rigsby.yml
@@ -2,7 +2,7 @@ id: jim-rigsby
 name: Jim Rigsby
 firstName: Jim
 lastName: Rigsby
-fullName: Jim Rigsby
+fullName: James William Rigsby
 abbreviation: RIG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jimmy-daywalt.yml
+++ b/src/data/drivers/jimmy-daywalt.yml
@@ -2,7 +2,7 @@ id: jimmy-daywalt
 name: Jimmy Daywalt
 firstName: Jimmy
 lastName: Daywalt
-fullName: Jimmy Daywalt
+fullName: James Edward Daywalt
 abbreviation: DAY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jimmy-jackson.yml
+++ b/src/data/drivers/jimmy-jackson.yml
@@ -2,7 +2,7 @@ id: jimmy-jackson
 name: Jimmy Jackson
 firstName: Jimmy
 lastName: Jackson
-fullName: Jimmy Jackson
+fullName: James Merriman Jackson
 abbreviation: JAC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jo-gartner.yml
+++ b/src/data/drivers/jo-gartner.yml
@@ -2,7 +2,7 @@ id: jo-gartner
 name: Jo Gartner
 firstName: Jo
 lastName: Gartner
-fullName: Josef Gartner
+fullName: Josef Anton Gartner
 abbreviation: GAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jo-schlesser.yml
+++ b/src/data/drivers/jo-schlesser.yml
@@ -2,7 +2,7 @@ id: jo-schlesser
 name: Jo Schlesser
 firstName: Jo
 lastName: Schlesser
-fullName: Joseph Schlesser
+fullName: Joseph Théodule Marie Schlesser
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/joe-james.yml
+++ b/src/data/drivers/joe-james.yml
@@ -2,7 +2,7 @@ id: joe-james
 name: Joe James
 firstName: Joe
 lastName: James
-fullName: Joe James
+fullName: Joseph David James
 abbreviation: JAM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/joe-kelly.yml
+++ b/src/data/drivers/joe-kelly.yml
@@ -2,7 +2,7 @@ id: joe-kelly
 name: Joe Kelly
 firstName: Joe
 lastName: Kelly
-fullName: Joe Kelly
+fullName: Joseph Michael Kelly
 abbreviation: KEL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-james.yml
+++ b/src/data/drivers/john-james.yml
@@ -2,7 +2,7 @@ id: john-james
 name: John James
 firstName: John
 lastName: James
-fullName: John James
+fullName: John Martin James
 abbreviation: JAM
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-miles.yml
+++ b/src/data/drivers/john-miles.yml
@@ -2,7 +2,7 @@ id: john-miles
 name: John Miles
 firstName: John
 lastName: Miles
-fullName: John Miles
+fullName: John Jeremy Miles
 abbreviation: MIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-nicholson.yml
+++ b/src/data/drivers/john-nicholson.yml
@@ -2,7 +2,7 @@ id: john-nicholson
 name: John Nicholson
 firstName: John
 lastName: Nicholson
-fullName: John Nicholson
+fullName: John Barry Nicholson
 abbreviation: NIC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-riseley-prichard.yml
+++ b/src/data/drivers/john-riseley-prichard.yml
@@ -2,7 +2,7 @@ id: john-riseley-prichard
 name: John Riseley-Prichard
 firstName: John
 lastName: Riseley-Prichard
-fullName: John Henry Estlin Augustin Prichard
+fullName: John Henry Estlin Augustin Riseley-Prichard
 abbreviation: RIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-riseley-prichard.yml
+++ b/src/data/drivers/john-riseley-prichard.yml
@@ -2,7 +2,7 @@ id: john-riseley-prichard
 name: John Riseley-Prichard
 firstName: John
 lastName: Riseley-Prichard
-fullName: John Henry Augustin Riseley-Prichard
+fullName: John Henry Estlin Augustin Prichard, later Riseley-Prichard
 abbreviation: RIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-riseley-prichard.yml
+++ b/src/data/drivers/john-riseley-prichard.yml
@@ -2,7 +2,7 @@ id: john-riseley-prichard
 name: John Riseley-Prichard
 firstName: John
 lastName: Riseley-Prichard
-fullName: John Henry Estlin Augustin Prichard, later Riseley-Prichard
+fullName: John Henry Estlin Augustin Prichard
 abbreviation: RIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/john-surtees.yml
+++ b/src/data/drivers/john-surtees.yml
@@ -2,7 +2,7 @@ id: john-surtees
 name: John Surtees
 firstName: John
 lastName: Surtees
-fullName: John Surtees
+fullName: John Norman Surtees
 abbreviation: SUR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/johnnie-parsons.yml
+++ b/src/data/drivers/johnnie-parsons.yml
@@ -2,7 +2,7 @@ id: johnnie-parsons
 name: Johnnie Parsons
 firstName: Johnnie
 lastName: Parsons
-fullName: Johnnie Woodrow Parsons
+fullName: John Woodrow Parsons
 abbreviation: PAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/johnny-mcdowell.yml
+++ b/src/data/drivers/johnny-mcdowell.yml
@@ -2,7 +2,7 @@ id: johnny-mcdowell
 name: Johnny McDowell
 firstName: Johnny
 lastName: McDowell
-fullName: Johnny McDowell
+fullName: John Maxwell McDowell
 abbreviation: MCD
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/johnny-thomson.yml
+++ b/src/data/drivers/johnny-thomson.yml
@@ -2,7 +2,7 @@ id: johnny-thomson
 name: Johnny Thomson
 firstName: Johnny
 lastName: Thomson
-fullName: Johnny Thomson
+fullName: John Ashley Thomson
 abbreviation: THO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/jonathan-williams.yml
+++ b/src/data/drivers/jonathan-williams.yml
@@ -2,7 +2,7 @@ id: jonathan-williams
 name: Jonathan Williams
 firstName: Jonathan
 lastName: Williams
-fullName: Jonathan Williams
+fullName: Jonathan James Williams
 abbreviation: WIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/keith-andrews.yml
+++ b/src/data/drivers/keith-andrews.yml
@@ -2,7 +2,7 @@ id: keith-andrews
 name: Keith Andrews
 firstName: Keith
 lastName: Andrews
-fullName: Keith Andrews
+fullName: Keith Phillip Andrews
 abbreviation: AND
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/keith-greene.yml
+++ b/src/data/drivers/keith-greene.yml
@@ -2,7 +2,7 @@ id: keith-greene
 name: Keith Greene
 firstName: Keith
 lastName: Greene
-fullName: Keith Greene
+fullName: Keith Anthony Greene
 abbreviation: GRE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ken-wharton.yml
+++ b/src/data/drivers/ken-wharton.yml
@@ -2,7 +2,7 @@ id: ken-wharton
 name: Ken Wharton
 firstName: Ken
 lastName: Wharton
-fullName: Ken Wharton
+fullName: Frederick Charles Kenneth Wharton
 abbreviation: WHA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/kevin-cogan.yml
+++ b/src/data/drivers/kevin-cogan.yml
@@ -2,7 +2,7 @@ id: kevin-cogan
 name: Kevin Cogan
 firstName: Kevin
 lastName: Cogan
-fullName: John Cogan
+fullName: John Kevin Cogan
 abbreviation: COG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/lance-reventlow.yml
+++ b/src/data/drivers/lance-reventlow.yml
@@ -2,7 +2,7 @@ id: lance-reventlow
 name: Lance Reventlow
 firstName: Lance
 lastName: Reventlow
-fullName: Lawrence Graf von Haugwitz-Hardenberg-Reventlow
+fullName: Lance George William Detlev Graf Haugwitz-Hardenberg-Reventlow
 abbreviation: REV
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/larry-crockett.yml
+++ b/src/data/drivers/larry-crockett.yml
@@ -2,7 +2,7 @@ id: larry-crockett
 name: Larry Crockett
 firstName: Larry
 lastName: Crockett
-fullName: Larry Crockett
+fullName: Larret Julian Crockett
 abbreviation: CRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/lee-wallard.yml
+++ b/src/data/drivers/lee-wallard.yml
@@ -2,7 +2,7 @@ id: lee-wallard
 name: Lee Wallard
 firstName: Lee
 lastName: Wallard
-fullName: Lee Wallard
+fullName: Leland Wallard
 abbreviation: WAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/leslie-marr.yml
+++ b/src/data/drivers/leslie-marr.yml
@@ -2,7 +2,7 @@ id: leslie-marr
 name: Leslie Marr
 firstName: Leslie
 lastName: Marr
-fullName: Leslie Marr
+fullName: Leslie Lynn Marr
 abbreviation: MAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/liam-lawson.yml
+++ b/src/data/drivers/liam-lawson.yml
@@ -2,7 +2,7 @@ id: liam-lawson
 name: Liam Lawson
 firstName: Liam
 lastName: Lawson
-fullName: Liam Lawson
+fullName: Liam Jared Lawson
 abbreviation: LAW
 permanentNumber: 30
 gender: MALE

--- a/src/data/drivers/louis-rosier.yml
+++ b/src/data/drivers/louis-rosier.yml
@@ -2,7 +2,7 @@ id: louis-rosier
 name: Louis Rosier
 firstName: Louis
 lastName: Rosier
-fullName: Louis Rosier
+fullName: Louis Claude Rosier
 abbreviation: ROS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/marcus-ericsson.yml
+++ b/src/data/drivers/marcus-ericsson.yml
@@ -2,7 +2,7 @@ id: marcus-ericsson
 name: Marcus Ericsson
 firstName: Marcus
 lastName: Ericsson
-fullName: Marcus Ericsson
+fullName: Marcus Thorbjörn Ericsson
 abbreviation: ERI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mario-de-araujo-cabral.yml
+++ b/src/data/drivers/mario-de-araujo-cabral.yml
@@ -2,7 +2,7 @@ id: mario-de-araujo-cabral
 name: Mário de Araújo Cabral
 firstName: Mário de Araújo
 lastName: Cabral
-fullName: Mário Veloso de Araújo Cabral
+fullName: Mário Manuel Veloso de Araújo Cabral
 abbreviation: DEA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mauro-baldi.yml
+++ b/src/data/drivers/mauro-baldi.yml
@@ -2,7 +2,7 @@ id: mauro-baldi
 name: Mauro Baldi
 firstName: Mauro
 lastName: Baldi
-fullName: Mauro Baldi
+fullName: Mauro Giuseppe Baldi
 abbreviation: BAL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/michael-bartels.yml
+++ b/src/data/drivers/michael-bartels.yml
@@ -2,7 +2,7 @@ id: michael-bartels
 name: Michael Bartels
 firstName: Michael
 lastName: Bartels
-fullName: Michael Bartels
+fullName: Michael Wilhelm Bartels
 abbreviation: BAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-fisher.yml
+++ b/src/data/drivers/mike-fisher.yml
@@ -2,7 +2,7 @@ id: mike-fisher
 name: Mike Fisher
 firstName: Mike
 lastName: Fisher
-fullName: Michael J. Fisher
+fullName: Michael Jeffry Fisher
 abbreviation: FIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-magill.yml
+++ b/src/data/drivers/mike-magill.yml
@@ -2,7 +2,7 @@ id: mike-magill
 name: Mike Magill
 firstName: Mike
 lastName: Magill
-fullName: Charles Michael Magill
+fullName: Charles Edward Magill
 abbreviation: MAG
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-nazaruk.yml
+++ b/src/data/drivers/mike-nazaruk.yml
@@ -2,7 +2,7 @@ id: mike-nazaruk
 name: Mike Nazaruk
 firstName: Mike
 lastName: Nazaruk
-fullName: Mike Nazaruk
+fullName: Michael Nazaruk
 abbreviation: NAZ
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-taylor.yml
+++ b/src/data/drivers/mike-taylor.yml
@@ -2,7 +2,7 @@ id: mike-taylor
 name: Mike Taylor
 firstName: Mike
 lastName: Taylor
-fullName: Mike Taylor
+fullName: Michael John Clifford Taylor
 abbreviation: TAY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-thackwell.yml
+++ b/src/data/drivers/mike-thackwell.yml
@@ -2,7 +2,7 @@ id: mike-thackwell
 name: Mike Thackwell
 firstName: Mike
 lastName: Thackwell
-fullName: Mike Thackwell
+fullName: Michael Christopher Thackwell
 abbreviation: THA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/mike-wilds.yml
+++ b/src/data/drivers/mike-wilds.yml
@@ -2,7 +2,7 @@ id: mike-wilds
 name: Mike Wilds
 firstName: Mike
 lastName: Wilds
-fullName: Mike Wilds
+fullName: William Michael Wilds
 abbreviation: WIL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/myron-fohr.yml
+++ b/src/data/drivers/myron-fohr.yml
@@ -2,7 +2,7 @@ id: myron-fohr
 name: Myron Fohr
 firstName: Myron
 lastName: Fohr
-fullName: Myron W. Fohr
+fullName: Myron William Fohr
 abbreviation: FOH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/nicholas-latifi.yml
+++ b/src/data/drivers/nicholas-latifi.yml
@@ -2,7 +2,7 @@ id: nicholas-latifi
 name: Nicholas Latifi
 firstName: Nicholas
 lastName: Latifi
-fullName: Nicholas Latifi
+fullName: Nicholas Daniel Latifi
 abbreviation: LAT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/nicola-larini.yml
+++ b/src/data/drivers/nicola-larini.yml
@@ -2,7 +2,7 @@ id: nicola-larini
 name: Nicola Larini
 firstName: Nicola
 lastName: Larini
-fullName: Nicola Larini
+fullName: Nicola Giuseppe Larini
 abbreviation: LAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/nikita-mazepin.yml
+++ b/src/data/drivers/nikita-mazepin.yml
@@ -2,7 +2,7 @@ id: nikita-mazepin
 name: Nikita Mazepin
 firstName: Nikita
 lastName: Mazepin
-fullName: Nikita Dmitryevich Mazepin
+fullName: Nikita Dmitriyevich Mazepin
 abbreviation: MAZ
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/nino-farina.yml
+++ b/src/data/drivers/nino-farina.yml
@@ -2,7 +2,7 @@ id: nino-farina
 name: Nino Farina
 firstName: Nino
 lastName: Farina
-fullName: Giuseppe Antonio Farina
+fullName: Emilio Giuseppe Farina
 abbreviation: FAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/nyck-de-vries.yml
+++ b/src/data/drivers/nyck-de-vries.yml
@@ -2,7 +2,7 @@ id: nyck-de-vries
 name: Nyck de Vries
 firstName: Nyck
 lastName: De Vries
-fullName: Nyck de Vries
+fullName: Hendrik Johannes Nicasius de Vries
 abbreviation: DEV
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/olivier-beretta.yml
+++ b/src/data/drivers/olivier-beretta.yml
@@ -2,7 +2,7 @@ id: olivier-beretta
 name: Olivier Beretta
 firstName: Olivier
 lastName: Beretta
-fullName: Olivier Beretta
+fullName: Olivier Henri Aldo Léopold Beretta
 abbreviation: BER
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/olivier-gendebien.yml
+++ b/src/data/drivers/olivier-gendebien.yml
@@ -2,7 +2,7 @@ id: olivier-gendebien
 name: Olivier Gendebien
 firstName: Olivier
 lastName: Gendebien
-fullName: Olivier Gendebien
+fullName: Olivier Jean Marie Fernand Gendebien
 abbreviation: GEN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/olivier-panis.yml
+++ b/src/data/drivers/olivier-panis.yml
@@ -2,7 +2,7 @@ id: olivier-panis
 name: Olivier Panis
 firstName: Olivier
 lastName: Panis
-fullName: Olivier Panis
+fullName: Olivier Jean Denis Marie Panis
 abbreviation: PAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/oscar-gonzalez.yml
+++ b/src/data/drivers/oscar-gonzalez.yml
@@ -2,7 +2,7 @@ id: oscar-gonzalez
 name: Óscar González
 firstName: Óscar
 lastName: González
-fullName: Óscar Mario González
+fullName: Óscar Mario González Alonso
 abbreviation: GON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/oscar-piastri.yml
+++ b/src/data/drivers/oscar-piastri.yml
@@ -2,7 +2,7 @@ id: oscar-piastri
 name: Oscar Jack Piastri
 firstName: Oscar
 lastName: Piastri
-fullName: Oscar Piastri
+fullName: Oscar Jack Piastri
 abbreviation: PIA
 permanentNumber: 81
 gender: MALE

--- a/src/data/drivers/otto-stuppacher.yml
+++ b/src/data/drivers/otto-stuppacher.yml
@@ -2,7 +2,7 @@ id: otto-stuppacher
 name: Otto Stuppacher
 firstName: Otto
 lastName: Stuppacher
-fullName: Otto Stuppacher
+fullName: Otto Leopold Stuppacher
 abbreviation: STU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/paddy-driver.yml
+++ b/src/data/drivers/paddy-driver.yml
@@ -2,7 +2,7 @@ id: paddy-driver
 name: Paddy Driver
 firstName: Paddy
 lastName: Driver
-fullName: Paddy Driver
+fullName: Ernest Gould Driver
 abbreviation: DRI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/pascal-wehrlein.yml
+++ b/src/data/drivers/pascal-wehrlein.yml
@@ -2,7 +2,7 @@ id: pascal-wehrlein
 name: Pascal Wehrlein
 firstName: Pascal
 lastName: Wehrlein
-fullName: Pascal Wehrlein
+fullName: Pascal Konrad Wehrlein
 abbreviation: WEH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/pat-flaherty.yml
+++ b/src/data/drivers/pat-flaherty.yml
@@ -2,7 +2,7 @@ id: pat-flaherty
 name: Pat Flaherty
 firstName: Pat
 lastName: Flaherty
-fullName: George Francis Flaherty, Jr.
+fullName: George Francis Flaherty
 abbreviation: FLA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/pat-oconnor.yml
+++ b/src/data/drivers/pat-oconnor.yml
@@ -2,7 +2,7 @@ id: pat-oconnor
 name: Pat O'Connor
 firstName: Pat
 lastName: O'Connor
-fullName: Pat O'Connor
+fullName: Patrick James O'Connor
 abbreviation: O'C
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/paul-russo.yml
+++ b/src/data/drivers/paul-russo.yml
@@ -2,7 +2,7 @@ id: paul-russo
 name: Paul Russo
 firstName: Paul
 lastName: Russo
-fullName: Paul Russo
+fullName: Paul Frank Russo
 abbreviation: RUS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/perry-mccarthy.yml
+++ b/src/data/drivers/perry-mccarthy.yml
@@ -2,7 +2,7 @@ id: perry-mccarthy
 name: Perry McCarthy
 firstName: Perry
 lastName: McCarthy
-fullName: Perry McCarthy
+fullName: Perry Edward McCarthy
 abbreviation: MCC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/peter-arundell.yml
+++ b/src/data/drivers/peter-arundell.yml
@@ -2,7 +2,7 @@ id: peter-arundell
 name: Peter Arundell
 firstName: Peter
 lastName: Arundell
-fullName: Peter Arundell
+fullName: Peter John Arundell
 abbreviation: ARU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/peter-broeker.yml
+++ b/src/data/drivers/peter-broeker.yml
@@ -2,7 +2,7 @@ id: peter-broeker
 name: Peter Broeker
 firstName: Peter
 lastName: Broeker
-fullName: Peter Broeker
+fullName: Peter William Broeker
 abbreviation: BRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/peter-de-klerk.yml
+++ b/src/data/drivers/peter-de-klerk.yml
@@ -2,7 +2,7 @@ id: peter-de-klerk
 name: Peter de Klerk
 firstName: Peter
 lastName: De Klerk
-fullName: Peter de Klerk
+fullName: Peter David de Klerk
 abbreviation: DEK
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/peter-revson.yml
+++ b/src/data/drivers/peter-revson.yml
@@ -2,7 +2,7 @@ id: peter-revson
 name: Peter Revson
 firstName: Peter
 lastName: Revson
-fullName: Peter Jeffrey Revson
+fullName: Peter Jeffrey Revlon Revson
 abbreviation: REV
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/peter-ryan.yml
+++ b/src/data/drivers/peter-ryan.yml
@@ -2,7 +2,7 @@ id: peter-ryan
 name: Peter Ryan
 firstName: Peter
 lastName: Ryan
-fullName: Peter B. Ryan
+fullName: Peter Barry Ryan
 abbreviation: RYA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/phil-cade.yml
+++ b/src/data/drivers/phil-cade.yml
@@ -2,7 +2,7 @@ id: phil-cade
 name: Phil Cade
 firstName: Phil
 lastName: Cade
-fullName: Phil Cade
+fullName: Philip Joseph Cade
 abbreviation: CAD
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/philippe-alliot.yml
+++ b/src/data/drivers/philippe-alliot.yml
@@ -2,7 +2,7 @@ id: philippe-alliot
 name: Philippe Alliot
 firstName: Philippe
 lastName: Alliot
-fullName: Philippe Alliot
+fullName: Philippe René Gabriel Alliot
 abbreviation: ALL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/philippe-etancelin.yml
+++ b/src/data/drivers/philippe-etancelin.yml
@@ -2,7 +2,7 @@ id: philippe-etancelin
 name: Philippe Étancelin
 firstName: Philippe
 lastName: Étancelin
-fullName: Philippe Étancelin
+fullName: Philippe Jean Armand Étancelin
 abbreviation: ETA
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/philippe-streiff.yml
+++ b/src/data/drivers/philippe-streiff.yml
@@ -2,7 +2,7 @@ id: philippe-streiff
 name: Philippe Streiff
 firstName: Philippe
 lastName: Streiff
-fullName: Philippe Streiff
+fullName: Philippe Pierre Streiff
 abbreviation: STR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/piero-taruffi.yml
+++ b/src/data/drivers/piero-taruffi.yml
@@ -2,7 +2,7 @@ id: piero-taruffi
 name: Piero Taruffi
 firstName: Piero
 lastName: Taruffi
-fullName: Piero Taruffi
+fullName: Pierino Antonio Alberto Taruffi
 abbreviation: TAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/pierre-gasly.yml
+++ b/src/data/drivers/pierre-gasly.yml
@@ -2,7 +2,7 @@ id: pierre-gasly
 name: Pierre Gasly
 firstName: Pierre
 lastName: Gasly
-fullName: Pierre Gasly
+fullName: Pierre Jean-Jacques Gasly
 abbreviation: GAS
 permanentNumber: 10
 gender: MALE

--- a/src/data/drivers/reine-wisell.yml
+++ b/src/data/drivers/reine-wisell.yml
@@ -2,7 +2,7 @@ id: reine-wisell
 name: Reine Wisell
 firstName: Reine
 lastName: Wisell
-fullName: Reine Wisell
+fullName: Reine Tore Leif Wisell
 abbreviation: WIS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/rob-schroeder.yml
+++ b/src/data/drivers/rob-schroeder.yml
@@ -2,7 +2,7 @@ id: rob-schroeder
 name: Rob Schroeder
 firstName: Rob
 lastName: Schroeder
-fullName: Robert Schroeder
+fullName: Robert Edward Schroeder
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/robert-manzon.yml
+++ b/src/data/drivers/robert-manzon.yml
@@ -2,7 +2,7 @@ id: robert-manzon
 name: Robert Manzon
 firstName: Robert
 lastName: Manzon
-fullName: Robert Manzon
+fullName: Robert Jean Joseph Manzon
 abbreviation: MAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/robin-montgomerie-charrington.yml
+++ b/src/data/drivers/robin-montgomerie-charrington.yml
@@ -2,7 +2,7 @@ id: robin-montgomerie-charrington
 name: Robin Montgomerie-Charrington
 firstName: Robin
 lastName: Montgomerie-Charrington
-fullName: Robert Victor Campbell Montgomerie
+fullName: Robin Victor Campbell Montgomerie-Charrington
 abbreviation: MON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/rodger-ward.yml
+++ b/src/data/drivers/rodger-ward.yml
@@ -2,7 +2,7 @@ id: rodger-ward
 name: Rodger Ward
 firstName: Rodger
 lastName: Ward
-fullName: Rodger M. Ward
+fullName: Rodger Morris Ward
 abbreviation: WAR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/rodney-nuckey.yml
+++ b/src/data/drivers/rodney-nuckey.yml
@@ -2,7 +2,7 @@ id: rodney-nuckey
 name: Rodney Nuckey
 firstName: Rodney
 lastName: Nuckey
-fullName: Rodney Nuckey
+fullName: Rodney York Nuckey
 abbreviation: NUC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/roger-loyer.yml
+++ b/src/data/drivers/roger-loyer.yml
@@ -2,7 +2,7 @@ id: roger-loyer
 name: Roger Loyer
 firstName: Roger
 lastName: Loyer
-fullName: Roger Loyer
+fullName: Roger Auguste Loyer
 abbreviation: LOY
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/roger-penske.yml
+++ b/src/data/drivers/roger-penske.yml
@@ -2,7 +2,7 @@ id: roger-penske
 name: Roger Penske
 firstName: Roger
 lastName: Penske
-fullName: Roger S. Penske
+fullName: Roger Searle Penske
 abbreviation: PEN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/roland-ratzenberger.yml
+++ b/src/data/drivers/roland-ratzenberger.yml
@@ -2,7 +2,7 @@ id: roland-ratzenberger
 name: Roland Ratzenberger
 firstName: Roland
 lastName: Ratzenberger
-fullName: Roland Ratzenberger
+fullName: Roland Walter Ratzenberger
 abbreviation: RAT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/romain-grosjean.yml
+++ b/src/data/drivers/romain-grosjean.yml
@@ -2,7 +2,7 @@ id: romain-grosjean
 name: Romain Grosjean
 firstName: Romain
 lastName: Grosjean
-fullName: Romain Grosjean
+fullName: Romain David Jeremie Grosjean
 abbreviation: GRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ron-flockhart.yml
+++ b/src/data/drivers/ron-flockhart.yml
@@ -2,7 +2,7 @@ id: ron-flockhart
 name: Ron Flockhart
 firstName: Ron
 lastName: Flockhart
-fullName: Ron Flockhart
+fullName: William Ronald Flockhart
 abbreviation: FLO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ronnie-bucknum.yml
+++ b/src/data/drivers/ronnie-bucknum.yml
@@ -2,7 +2,7 @@ id: ronnie-bucknum
 name: Ronnie Bucknum
 firstName: Ronnie
 lastName: Bucknum
-fullName: Ronnie Bucknum
+fullName: Ronald James Bucknum
 abbreviation: BUC
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/sam-hanks.yml
+++ b/src/data/drivers/sam-hanks.yml
@@ -2,7 +2,7 @@ id: sam-hanks
 name: Sam Hanks
 firstName: Sam
 lastName: Hanks
-fullName: Sam Hanks
+fullName: Samuel Dwight Hanks
 abbreviation: HAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/sam-posey.yml
+++ b/src/data/drivers/sam-posey.yml
@@ -2,7 +2,7 @@ id: sam-posey
 name: Sam Posey
 firstName: Sam
 lastName: Posey
-fullName: Sam Posey
+fullName: Samuel Felton Posey
 abbreviation: POS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/sam-tingle.yml
+++ b/src/data/drivers/sam-tingle.yml
@@ -2,7 +2,7 @@ id: sam-tingle
 name: Sam Tingle
 firstName: Sam
 lastName: Tingle
-fullName: Samuel Tingle
+fullName: Sam Ashworth Tingle
 abbreviation: TIN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/sebastien-buemi.yml
+++ b/src/data/drivers/sebastien-buemi.yml
@@ -2,7 +2,7 @@ id: sebastien-buemi
 name: Sébastien Buemi
 firstName: Sébastien
 lastName: Buemi
-fullName: Sébastien Olivier Buemi
+fullName: Sébastien Olivier Humbert Buemi
 abbreviation: BUE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/sergio-perez.yml
+++ b/src/data/drivers/sergio-perez.yml
@@ -2,7 +2,7 @@ id: sergio-perez
 name: Sergio Pérez
 firstName: Sergio
 lastName: Pérez
-fullName: Sergio Pérez Mendoza
+fullName: Sergio Michel Pérez Mendoza
 abbreviation: PER
 permanentNumber: 11
 gender: MALE

--- a/src/data/drivers/slim-borgudd.yml
+++ b/src/data/drivers/slim-borgudd.yml
@@ -2,7 +2,7 @@ id: slim-borgudd
 name: Slim Borgudd
 firstName: Slim
 lastName: Borgudd
-fullName: Karl Edward Tommy Borgudd
+fullName: Karl Edvard Tommy Borgudd
 abbreviation: BOR
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/spider-webb.yml
+++ b/src/data/drivers/spider-webb.yml
@@ -2,7 +2,7 @@ id: spider-webb
 name: Spider Webb
 firstName: Spider
 lastName: Webb
-fullName: Travis Webb
+fullName: Travis Leon Webb
 abbreviation: WEB
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/stirling-moss.yml
+++ b/src/data/drivers/stirling-moss.yml
@@ -2,7 +2,7 @@ id: stirling-moss
 name: Stirling Moss
 firstName: Stirling
 lastName: Moss
-fullName: Sir Stirling Moss
+fullName: Stirling Craufurd Moss
 abbreviation: MOS
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/stoffel-vandoorne.yml
+++ b/src/data/drivers/stoffel-vandoorne.yml
@@ -2,7 +2,7 @@ id: stoffel-vandoorne
 name: Stoffel Vandoorne
 firstName: Stoffel
 lastName: Vandoorne
-fullName: Stoffel Vandoorne
+fullName: Stoffel Jacques Luc Vandoorne
 abbreviation: VAN
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/ted-whiteaway.yml
+++ b/src/data/drivers/ted-whiteaway.yml
@@ -2,7 +2,7 @@ id: ted-whiteaway
 name: Ted Whiteaway
 firstName: Ted
 lastName: Whiteaway
-fullName: Edward N. Whiteaway
+fullName: Edward Norton Whiteaway
 abbreviation: WHI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/theo-helfrich.yml
+++ b/src/data/drivers/theo-helfrich.yml
@@ -2,7 +2,7 @@ id: theo-helfrich
 name: Theo Helfrich
 firstName: Theo
 lastName: Helfrich
-fullName: Theodor Helfrich
+fullName: Theodor Karl Helfrich
 abbreviation: HEL
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/thierry-boutsen.yml
+++ b/src/data/drivers/thierry-boutsen.yml
@@ -2,7 +2,7 @@ id: thierry-boutsen
 name: Thierry Boutsen
 firstName: Thierry
 lastName: Boutsen
-fullName: Thierry Marc Boutsen
+fullName: Thierry Marc Alain Boutsen
 abbreviation: BOU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/tiago-monteiro.yml
+++ b/src/data/drivers/tiago-monteiro.yml
@@ -2,7 +2,7 @@ id: tiago-monteiro
 name: Tiago Monteiro
 firstName: Tiago
 lastName: Monteiro
-fullName: Tiago da Costa Monteiro
+fullName: Tiago Vagaroso da Costa Monteiro
 abbreviation: MON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/tiff-needell.yml
+++ b/src/data/drivers/tiff-needell.yml
@@ -2,7 +2,7 @@ id: tiff-needell
 name: Tiff Needell
 firstName: Tiff
 lastName: Needell
-fullName: Timothy Needell
+fullName: Timothy Richard Needell
 abbreviation: NEE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/tom-jones.yml
+++ b/src/data/drivers/tom-jones.yml
@@ -2,7 +2,7 @@ id: tom-jones
 name: Tom Jones
 firstName: Tom
 lastName: Jones
-fullName: Tom Jones
+fullName: Earl Thomas Jones
 abbreviation: JON
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/tony-crook.yml
+++ b/src/data/drivers/tony-crook.yml
@@ -2,7 +2,7 @@ id: tony-crook
 name: Tony Crook
 firstName: Tony
 lastName: Crook
-fullName: Anthony Crook
+fullName: Thomas Anthony Donald Crook
 abbreviation: CRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/tony-trimmer.yml
+++ b/src/data/drivers/tony-trimmer.yml
@@ -2,7 +2,7 @@ id: tony-trimmer
 name: Tony Trimmer
 firstName: Tony
 lastName: Trimmer
-fullName: Tony Trimmer
+fullName: Anthony Hugh Leigh Trimmer
 abbreviation: TRI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/troy-ruttman.yml
+++ b/src/data/drivers/troy-ruttman.yml
@@ -2,7 +2,7 @@ id: troy-ruttman
 name: Troy Ruttman
 firstName: Troy
 lastName: Ruttman
-fullName: Troy Ruttman
+fullName: Troy Lynn Ruttman
 abbreviation: RUT
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/vern-schuppan.yml
+++ b/src/data/drivers/vern-schuppan.yml
@@ -2,7 +2,7 @@ id: vern-schuppan
 name: Vern Schuppan
 firstName: Vern
 lastName: Schuppan
-fullName: Vernon Schuppan
+fullName: Vernon John Schuppan
 abbreviation: SCH
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/volker-weidler.yml
+++ b/src/data/drivers/volker-weidler.yml
@@ -2,7 +2,7 @@ id: volker-weidler
 name: Volker Weidler
 firstName: Volker
 lastName: Weidler
-fullName: Volker Weidler
+fullName: Volker Hermann Weidler
 abbreviation: WEI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/walt-ader.yml
+++ b/src/data/drivers/walt-ader.yml
@@ -2,7 +2,7 @@ id: walt-ader
 name: Walt Ader
 firstName: Walt
 lastName: Ader
-fullName: Walt Ader
+fullName: Walter Ader
 abbreviation: ADE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/walt-brown.yml
+++ b/src/data/drivers/walt-brown.yml
@@ -2,7 +2,7 @@ id: walt-brown
 name: Walt Brown
 firstName: Walt
 lastName: Brown
-fullName: Walt Brown
+fullName: Walter Charles Brown
 abbreviation: BRO
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/walt-faulkner.yml
+++ b/src/data/drivers/walt-faulkner.yml
@@ -2,7 +2,7 @@ id: walt-faulkner
 name: Walt Faulkner
 firstName: Walt
 lastName: Faulkner
-fullName: Walt Faulkner
+fullName: Walter Faulkner
 abbreviation: FAU
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/wayne-weiler.yml
+++ b/src/data/drivers/wayne-weiler.yml
@@ -2,7 +2,7 @@ id: wayne-weiler
 name: Wayne Weiler
 firstName: Wayne
 lastName: Weiler
-fullName: Wayne Weiler
+fullName: Wayne Alois Weiler
 abbreviation: WEI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/will-stevens.yml
+++ b/src/data/drivers/will-stevens.yml
@@ -2,7 +2,7 @@ id: will-stevens
 name: Will Stevens
 firstName: Will
 lastName: Stevens
-fullName: William Stevens
+fullName: William Jonathan Richard Stevens
 abbreviation: STE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/willi-heeks.yml
+++ b/src/data/drivers/willi-heeks.yml
@@ -2,7 +2,7 @@ id: willi-heeks
 name: Willi Heeks
 firstName: Willi
 lastName: Heeks
-fullName: Willi Heeks
+fullName: Wilhelm Heeks
 abbreviation: HEE
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/willy-mairesse.yml
+++ b/src/data/drivers/willy-mairesse.yml
@@ -2,7 +2,7 @@ id: willy-mairesse
 name: Willy Mairesse
 firstName: Willy
 lastName: Mairesse
-fullName: Willy Mairesse
+fullName: Willem Edouard Numa Ghislain Mairesse
 abbreviation: MAI
 permanentNumber:
 gender: MALE

--- a/src/data/drivers/yannick-dalmas.yml
+++ b/src/data/drivers/yannick-dalmas.yml
@@ -2,7 +2,7 @@ id: yannick-dalmas
 name: Yannick Dalmas
 firstName: Yannick
 lastName: Dalmas
-fullName: Yannick Dalmas
+fullName: Yannick Paul Marie Dalmas
 abbreviation: DAL
 permanentNumber:
 gender: MALE


### PR DESCRIPTION
I manually went through wikipedia articles and updated these driver names and manually verified. 

There are few names I'm not sure which way to go

src/data/drivers/antonio-giovinazzi.yml - removed jr
src/data/drivers/frank-armi.yml - there is a jr in the name
src/data/drivers/george-amick.yml - jr in name
src/data/drivers/jack-turner.yml - jr in name
src/data/drivers/john-riseley-prichard.yml- later Riseley-Prichard
src/data/drivers/pat-flaherty.yml - removed jr
src/data/drivers/stirling-moss.yml - removed sir because it is honorary title, otherwise we would also need to update several other drivers who have honorary titles to keep the data consistent.

some drivers have different names from their birth names eg. William Vukovich born Vaso Vukovich, which one do we use? 

Wikipedia has driver names with their nicknames included eg. Sergio Michel "Checo" Pérez Mendoza. I didn't add these nick names but when I search for Checo, there will be no results.  

I propose adding a separate nickname field for drivers. What do you think? 


src/data/drivers/spider-webb.yml -  https://en.wikipedia.org/wiki/Travis_Webb  - his firstname needs to changed - spider was just his nickname. I focused this PR only on full names but I can submit a new PR for this change. what do you think?

for driver https://en.wikipedia.org/wiki/Antonio_Creus - there is a 'i' in the name - do we want to add the "i" or leave it as is?