### PR TITLE
Correct name and fullName fields for Oscar Piastri

### DIFF
--- a/src/data/drivers/oscar-piastri.yml
+++ b/src/data/drivers/oscar-piastri.yml
@@ -1,8 +1,8 @@
 id: oscar-piastri
-name: Oscar Jack Piastri
+name: Oscar Piastri
 firstName: Oscar
 lastName: Piastri
-fullName: Oscar Piastri
+fullName: Oscar Jack Piastri
 abbreviation: PIA
 permanentNumber: 81
 gender: MALE


### PR DESCRIPTION
Hi again,

I noticed that Oscar Piastri's `name` and `fullName` fields were accidentally swapped in the driver data. This PR corrects the mismatch.

### Changes
- **name**: Oscar Jack Piastri -> Oscar Piastri
- **fullName**: Oscar Piastri -> Oscar Jack Piastri

Thanks!