### PR TITLE
fix: update driver of the day percentages for multiple seasons

### DIFF
--- a/src/data/seasons/2020/races/04-great-britain/driver-of-the-day-results.yml
+++ b/src/data/seasons/2020/races/04-great-britain/driver-of-the-day-results.yml
@@ -4,28 +4,28 @@
   constructorId: mercedes
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage:
+  percentage: 9.93
 - position: 2
   driverNumber: 33
   driverId: max-verstappen
   constructorId: red-bull
   engineManufacturerId: honda
   tyreManufacturerId: pirelli
-  percentage:
+  percentage: 9.69
 - position: 3
   driverNumber: 4
   driverId: lando-norris
   constructorId: mclaren
   engineManufacturerId: renault
   tyreManufacturerId: pirelli
-  percentage:
+  percentage: 8.53
 - position: 4
   driverNumber: 55
   driverId: carlos-sainz-jr
   constructorId: mclaren
   engineManufacturerId: renault
   tyreManufacturerId: pirelli
-  percentage:
+  percentage: 8.33
 - position: 5
   driverNumber: 23
   driverId: alexander-albon

--- a/src/data/seasons/2024/races/24-abu-dhabi/driver-of-the-day-results.yml
+++ b/src/data/seasons/2024/races/24-abu-dhabi/driver-of-the-day-results.yml
@@ -18,7 +18,7 @@
   constructorId: mclaren
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 12.3
+  percentage: 12.2
 - position: 4
   driverNumber: 55
   driverId: carlos-sainz-jr

--- a/src/data/seasons/2025/races/01-australia/driver-of-the-day-results.yml
+++ b/src/data/seasons/2025/races/01-australia/driver-of-the-day-results.yml
@@ -4,32 +4,32 @@
   constructorId: mclaren
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 20.7
+  percentage: 23.97
 - position: 2
+  driverNumber: 12
+  driverId: kimi-antonelli
+  constructorId: mercedes
+  engineManufacturerId: mercedes
+  tyreManufacturerId: pirelli
+  percentage: 16.08
+- position: 3
   driverNumber: 81
   driverId: oscar-piastri
   constructorId: mclaren
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 17.2
-- position: 3
+  percentage: 11.25
+- position: 4
   driverNumber: 23
   driverId: alexander-albon
   constructorId: williams
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 15.9
-- position: 4
-  driverNumber: 22
-  driverId: yuki-tsunoda
-  constructorId: racing-bulls
+  percentage: 10.87
+- position: 5
+  driverNumber: 1
+  driverId: max-verstappen
+  constructorId: red-bull
   engineManufacturerId: honda-rbpt
   tyreManufacturerId: pirelli
-  percentage: 11.3
-- position: 5
-  driverNumber: 44
-  driverId: lewis-hamilton
-  constructorId: ferrari
-  engineManufacturerId: ferrari
-  tyreManufacturerId: pirelli
-  percentage: 8.3
+  percentage: 9.01

--- a/src/data/seasons/2026/races/02-china/driver-of-the-day-results.yml
+++ b/src/data/seasons/2026/races/02-china/driver-of-the-day-results.yml
@@ -4,32 +4,32 @@
   constructorId: mercedes
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 20.7
+  percentage: 23.43
 - position: 2
-  driverNumber: 81
-  driverId: oscar-piastri
-  constructorId: mclaren
+  driverNumber: 44
+  driverId: lewis-hamilton
+  constructorId: ferrari
+  engineManufacturerId: ferrari
+  tyreManufacturerId: pirelli
+  percentage: 22.28
+- position: 3
+  driverNumber: 43
+  driverId: franco-colapinto
+  constructorId: alpine
   engineManufacturerId: mercedes
   tyreManufacturerId: pirelli
-  percentage: 15.6
-- position: 3
+  percentage: 11.4
+- position: 4
   driverNumber: 87
   driverId: oliver-bearman
   constructorId: haas
   engineManufacturerId: ferrari
   tyreManufacturerId: pirelli
-  percentage: 12.9
-- position: 4
-  driverNumber: 16
-  driverId: charles-leclerc
-  constructorId: ferrari
-  engineManufacturerId: ferrari
-  tyreManufacturerId: pirelli
-  percentage: 8.4
+  percentage: 10.15
 - position: 5
   driverNumber: 3
   driverId: max-verstappen
   constructorId: red-bull
   engineManufacturerId: red-bull-ford
   tyreManufacturerId: pirelli
-  percentage: 6.5
+  percentage: 7.11


### PR DESCRIPTION


https://www.formula1.com/en/results/2020/awards/driver-of-the-day - 2020 British GP - Hulk won DOTD but DNS, so Lewis is officially DOTD according to f1 - https://www.formula1.com/en/latest/article/driver-of-the-day-2020.30G6kHOGAe7Wcz2KBwwObh

 
https://www.formula1.com/en/latest/article/driver-of-the-day-2024.1I7A0iPl3nMaXyPIeFVFLZ

https://www.formula1.com/en/latest/article/driver-of-the-day-2025.1vNM15UysUT1r3A2OMaFqH

https://www.formula1.com/en/results/2026/awards/driver-of-the-day

https://www.formula1.com/en/latest/article/driver-of-the-day.6dwMp9DDgssMeaAkgYuusQ - 2018 DOTD percentages are available in this article videos