### PR TITLE
Fix 2026 Great Britain results per official classification

### DIFF
--- a/src/data/seasons/2026/races/09-great-britain/race-results.yml
+++ b/src/data/seasons/2026/races/09-great-britain/race-results.yml
@@ -153,20 +153,6 @@
   points:
   gridPosition: 8
 - position: 12
-  driverNumber: 55
-  driverId: carlos-sainz-jr
-  constructorId: williams
-  engineManufacturerId: mercedes
-  tyreManufacturerId: pirelli
-  laps: 52
-  time: "1:27:15.726"
-  timePenalty:
-  gap: "+4.391"
-  interval: "+0.377"
-  reasonRetired:
-  points:
-  gridPosition: 14
-- position: 13
   driverNumber: 87
   driverId: oliver-bearman
   constructorId: haas
@@ -176,11 +162,11 @@
   time: "1:27:16.580"
   timePenalty:
   gap: "+5.245"
-  interval: "+0.854"
+  interval: "+1.231"
   reasonRetired:
   points:
   gridPosition: 13
-- position: 14
+- position: 13
   driverNumber: 31
   driverId: esteban-ocon
   constructorId: haas
@@ -194,7 +180,7 @@
   reasonRetired:
   points:
   gridPosition: 17
-- position: 15
+- position: 14
   driverNumber: 11
   driverId: sergio-perez
   constructorId: cadillac
@@ -208,7 +194,7 @@
   reasonRetired:
   points:
   gridPosition: 20
-- position: 16
+- position: 15
   driverNumber: 12
   driverId: kimi-antonelli
   constructorId: mercedes
@@ -222,7 +208,7 @@
   reasonRetired:
   points:
   gridPosition: 1
-- position: 17
+- position: 16
   driverNumber: 77
   driverId: valtteri-bottas
   constructorId: cadillac
@@ -236,6 +222,20 @@
   reasonRetired:
   points:
   gridPosition: 18
+- position: 17
+  driverNumber: 55
+  driverId: carlos-sainz-jr
+  constructorId: williams
+  engineManufacturerId: mercedes
+  tyreManufacturerId: pirelli
+  laps: 51
+  time:
+  timePenalty:
+  gap: "+1 lap"
+  interval:
+  reasonRetired:
+  points:
+  gridPosition: 14
 - position: 18
   driverNumber: 14
   driverId: fernando-alonso


### PR DESCRIPTION
Corrects 2026 Great Britain results to match FIA final race classification.

| Session | Driver | Field | f1db | official |
| --- | --- | --- | --- | --- |
| race | Oliver BEARMAN | position | 13 | 12 |
| race | Oliver BEARMAN | interval | +0.854 | +1.231 |
| race | Esteban OCON | position | 14 | 13 |
| race | Sergio PEREZ | position | 15 | 14 |
| race | Kimi ANTONELLI | position | 16 | 15 |
| race | Valtteri BOTTAS | position | 17 | 16 |
| race | Carlos SAINZ | position | 12 | 17 |
| race | Carlos SAINZ | laps | 52 | 51 |
| race | Carlos SAINZ | time | 1:27:15.726 | None |
| race | Carlos SAINZ | gap | +4.391 | +1 lap |
| race | Carlos SAINZ | interval | +0.377 | None |

Verified against:
- FIA final race classification: https://www.fia.com/system/files/decision-document/2026_british_grand_prix_-_final_race_classification.pdf