### PR TITLE
Add Scorewit F1 to Projects using F1DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ For a full list of all contributors, see [GitHub Contributors](https://github.co
 - ⚙️ [Gridvex API](https://api.gridvex.app/docs/api) - Free F1 REST API with comprehensive endpoints
 - 🤖 [OvertakeGP](https://play.google.com/store/apps/details?id=com.kkgosu.overtakegp) – OvertakeGP is a fast, focused Formula 1® companion that brings decades of racing data into one clean app
 - ⚙️ [RacingHub API](https://racinghub.net/api/v1/docs) – Free & open-source F1 REST API with Python/JS clients and MCP support
+- 🌐 [Scorewit F1](https://www.scorewit.com/f1) – Free daily Formula 1 history trivia with computed driver, constructor, season and circuit reference pages
 
 Are you using F1DB? We'd love to feature your project!\
 Please send us a message, create an [issue](https://github.com/f1db/f1db/issues/new), or open a pull request to add it here.


### PR DESCRIPTION
Adds one entry to the *Projects using F1DB* section (alphabetical placement after RacingHub API):

**[Scorewit F1](https://www.scorewit.com/f1)** — free daily Formula 1 history trivia: six questions a day, every answer computed from F1DB data and linked to its source, plus ~300 computed reference pages (drivers, constructors, seasons, circuits, records). A validator independently re-derives every published fact from the dataset before deploy.

CC BY 4.0 attribution to F1DB is carried in every page footer and each question's citation; the site's data sources are documented at https://www.scorewit.com/f1/llms.txt. Thanks for maintaining F1DB — happy to adjust wording, emoji, or placement to your conventions.