### PR TITLE
Add Apex Attribution to Projects using F1DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ For a full list of all contributors, see [GitHub Contributors](https://github.co
 
 ## Projects using F1DB
 
+- 🌐 [Apex Attribution](https://bolt-chaos.github.io/apex-attribution/) – Causal model separating driver skill from car performance, with an interactive "put any driver in any car" explorer
 - 🌐 [F1+](https://formula1.plus/) – F1 Predictions, Live Standings & Race Intelligence
 - 🍎 [F1nally](https://apps.apple.com/us/app/f1nally/id1618275556) – iOS app to quickly view the F1 schedule and results
 - 📅 [F1-Kalender](https://f1-kalender.nl/) – Dutch website with F1 schedule, iCal feed, weather predictions and results


### PR DESCRIPTION
Adds [Apex Attribution](https://github.com/bolt-chaos/apex-attribution) to the *Projects using F1DB* list (alphabetical placement).

**What it is:** a causal attribution metric for F1 drivers — it separates a driver's own contribution from the car they happened to be driving, by fitting a structural causal model and posing the classic bar argument (*driver or machinery?*) formally, as a `do(constructor = X)` intervention holding the driver fixed. Built with [DoWhy](https://github.com/py-why/dowhy) + PyMC on top of F1DB.

**How it uses F1DB:** qualifying times, race results and retirement reasons from the F1DB SQLite release (currently pinned to `v2026.11.0`) feed a hierarchical model that identifies driver skill from teammate comparisons — teammates share a car, and drivers changing teams chain those comparisons into a connected graph spanning the grid. F1DB's coverage back to 1950 is what makes the cross-era work possible at all; the teammate graph stays ~90% connected as far back as 1980, which puts Senna in the same component as Verstappen.

**Interactive site:** https://bolt-chaos.github.io/apex-attribution/ — fully static (the model is baked down to ~300 KB of JSON), so you can put any driver in any car, drag the era window, trace the teammate chain between two drivers, and compare careers head-to-head, all in the browser.

Attribution is credited in the README and in the site header: *F1 data from [f1db](https://github.com/f1db/f1db), licensed CC-BY-4.0.*

Thanks for maintaining this dataset — the schema and the tagged releases made the whole thing reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
